### PR TITLE
fix: update rerun set_time API for v0.28+ compatibility

### DIFF
--- a/mast3r_slam/api/inference.py
+++ b/mast3r_slam/api/inference.py
@@ -112,7 +112,7 @@ def mast3r_slam_inference(inf_config: InferenceConfig):
     start_time = timer()
 
     while True:
-        rr.set_time_sequence(timeline="frame", sequence=i)
+        rr.set_time("frame", sequence=i)
         mode: Mode = states.get_mode()
 
         if i == len(dataset):


### PR DESCRIPTION
## Description
This PR fixes a crash occurring during inference when using `rerun-sdk >= 0.28`.

The `rr.set_time_sequence()` function was removed in the v2 API update of the Rerun SDK. It has been replaced by the unified `rr.set_time()` function. Since other dependencies (like `simplecv`) may require recent versions of Rerun, this update ensures compatibility with the latest ecosystem.

## Changes
- Replaced `rr.set_time_sequence(timeline="frame", sequence=i)` with `rr.set_time("frame", sequence=i)` in `mast3r_slam/api/inference.py`.

## Impact
Prevents an immediate `AttributeError` crash on the first iteration of the inference loop when running with modern Rerun SDK versions.